### PR TITLE
[Bugfix] excessive usage of system file handles

### DIFF
--- a/videk-client
+++ b/videk-client
@@ -174,7 +174,8 @@ def readPipe(_pipe):
 
     try:
         io = os.open(FIFO, os.O_RDONLY | os.O_NONBLOCK)
-        buffer = os.read(io, 999999).decode('utf-8')
+        buffer = os.read(io, 65536).decode('utf-8') # 64k is default pipe size
+        os.close(io)
         data = buffer.splitlines()
 
     except:

--- a/videk-client
+++ b/videk-client
@@ -44,7 +44,7 @@ if "sys" in conf:
     sys = conf['sys']
 
 timeout = 600
-if conf['mode'] == "dev":
+if ('mode' in conf) and (conf['mode'] == "dev"):
     timeout = 10
 
 if "info" in conf:


### PR DESCRIPTION
- close pipe after reading it (when running for a long time system runs out of handles and prevents further readings)
- check if 'mode' dict key is present in configuration file (if it is not present, client will continue with default configuration)